### PR TITLE
Add Results page UI

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,22 +3,24 @@ import './styles/normalize.css'
 
 import { Layout } from './components/Layout/Layout.tsx'
 // import { Welcome } from './pages/Welcome.tsx'
-import { Game } from './pages/Game.tsx'
-import { GameData } from './types/types.ts'
-import { mockQuestionsMultiple } from './data/quizData.ts'
+// import { Game } from './pages/Game.tsx'
+// import { GameData } from './types/types.ts'
+// import { mockQuestionsMultiple } from './data/quizData.ts'
+import Results from './pages/Results.tsx'
 
-const mockData: GameData = {
-  difficulty: 'Medium',
-  type: 'Any type',
-  questionsAmount: 10,
-  category: 'Films'
-}
+// const mockData: GameData = {
+//   difficulty: 'Medium',
+//   type: 'Any type',
+//   questionsAmount: 10,
+//   category: 'Films'
+// }
 
 function App() {
   return (
     <Layout>
       {/*<Welcome />*/}
-      <Game data={mockData} questions={mockQuestionsMultiple} />
+      {/*<Game data={mockData} questions={mockQuestionsMultiple} />*/}
+      <Results />
     </Layout>
   )
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,23 +4,24 @@ import './styles/normalize.css'
 import { Layout } from './components/Layout/Layout.tsx'
 // import { Welcome } from './pages/Welcome.tsx'
 // import { Game } from './pages/Game.tsx'
-// import { GameData } from './types/types.ts'
+import { GameData } from './types/types.ts'
 // import { mockQuestionsMultiple } from './data/quizData.ts'
 import Results from './pages/Results.tsx'
 
-// const mockData: GameData = {
-//   difficulty: 'Medium',
-//   type: 'Any type',
-//   questionsAmount: 10,
-//   category: 'Films'
-// }
+const mockData: GameData = {
+  difficulty: 'Medium',
+  type: 'Any type',
+  questionsAmount: 10,
+  category: 'Films',
+  time: 5
+}
 
 function App() {
   return (
     <Layout>
       {/*<Welcome />*/}
       {/*<Game data={mockData} questions={mockQuestionsMultiple} />*/}
-      <Results />
+      <Results data={mockData} />
     </Layout>
   )
 }

--- a/src/components/ResultsTable/ResultsTable.module.scss
+++ b/src/components/ResultsTable/ResultsTable.module.scss
@@ -1,0 +1,52 @@
+@use 'src/styles/colors';
+
+.results {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.table {
+  &__heading {
+    display: grid;
+    grid-template-columns: 2fr 1fr 1fr 1fr;
+    font-weight: bold;
+    border-bottom: 1px solid colors.$white;
+  }
+
+  &__headingItem {
+    text-align: center;
+
+    &:last-child {
+      border-right: none;
+    }
+  }
+
+  &__data {
+    list-style: none;
+    padding-left: 0;
+
+  }
+
+  &__listItem {
+    display: grid;
+    grid-template-columns: 2fr 1fr 1fr 1fr;
+    padding: 0;
+  }
+
+  &__item {
+    text-align: center;
+
+    &:first-child {
+      text-align: left;
+    }
+  }
+}
+
+.correct {
+  color: colors.$correct;
+}
+
+.incorrect {
+  color: colors.$incorrect;
+}

--- a/src/components/ResultsTable/ResultsTable.tsx
+++ b/src/components/ResultsTable/ResultsTable.tsx
@@ -1,0 +1,31 @@
+import styles from './ResultsTable.module.scss'
+import { mockQuestionsMultiple } from '../../data/quizData.ts'
+import clsx from 'clsx'
+
+const QuizResultsTable = () => {
+  return (
+    <div className={styles.results}>
+      <h2>Quiz Results</h2>
+      <div className={styles.table}>
+        <div className={styles.table__heading}>
+          <p className={styles.table__headingItem}>Question</p>
+          <p className={clsx(styles.table__headingItem, styles.correct)}>Correct answer</p>
+          <p className={styles.table__headingItem}>Your answer</p>
+          <p className={styles.table__headingItem}>Result</p>
+        </div>
+        <ul className={styles.table__data}>
+          {mockQuestionsMultiple.map((el) => (
+            <li className={styles.table__listItem} key={el.question}>
+              <p className={styles.table__item}>{el.question}</p>
+              <p className={styles.table__item}>{el.correct_answer}</p>
+              <p className={styles.table__item}>User answer</p>
+              <p className={styles.table__item}>Result</p>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  )
+}
+
+export default QuizResultsTable

--- a/src/pages/Results.module.scss
+++ b/src/pages/Results.module.scss
@@ -18,6 +18,10 @@
 }
 
 .info {
+  &__item {
+    margin: 5px 0;
+    color: colors.$white-low-accent;
+  }
 }
 
 .buttons {

--- a/src/pages/Results.module.scss
+++ b/src/pages/Results.module.scss
@@ -1,0 +1,43 @@
+@use 'src/styles/colors';
+
+.results {
+  flex-grow: 1;
+}
+
+.container {
+  background-color: rgb(255 255 255 / 15%);
+  padding: 30px;
+  border-radius: 20px;
+}
+
+
+.focus {
+  color: yellow;
+  font-size: 20px;
+  font-weight: bold;
+}
+
+.info {
+}
+
+.buttons {
+  display: flex;
+  width: 100%;
+  justify-content: center;
+  gap: 20px;
+  margin-top: 30px;
+
+  &__item {
+    border: none;
+    padding: 15px 20px;
+    text-decoration: none;
+    color: black;
+    background-color: rgba(255, 255, 255, 0.86);
+    border-radius: 10px;
+    transition: .3s;
+
+    &:hover {
+      background-color: colors.$white;
+    }
+  }
+}

--- a/src/pages/Results.tsx
+++ b/src/pages/Results.tsx
@@ -1,8 +1,13 @@
+import { GameData } from '../types/types.ts'
 import { Link } from 'react-router-dom'
 import styles from './Results.module.scss'
 import QuizResultsTable from '../components/ResultsTable/ResultsTable.tsx'
 
-const Results = () => {
+interface ResultsProps {
+  data: GameData
+}
+
+const Results = ({ data }: ResultsProps) => {
   return (
     <div className={styles.results}>
       <h1>
@@ -11,6 +16,12 @@ const Results = () => {
       <div className={styles.container}>
         <div className={styles.info}>
           <h4>Overall:</h4>
+          <div className={styles.info}>
+            <p className={styles.info__item}>Category: {data.category}</p>
+            <p className={styles.info__item}>Difficulty: {data.difficulty}</p>
+            <p className={styles.info__item}>Type: {data.type}</p>
+            <p className={styles.info__item}>Time: {data.time} min</p>
+          </div>
           <p>
             You answered <span className={styles.focus}>5 out of 10</span> questions correctly
           </p>

--- a/src/pages/Results.tsx
+++ b/src/pages/Results.tsx
@@ -1,0 +1,35 @@
+import { Link } from 'react-router-dom'
+import styles from './Results.module.scss'
+import QuizResultsTable from '../components/ResultsTable/ResultsTable.tsx'
+
+const Results = () => {
+  return (
+    <div className={styles.results}>
+      <h1>
+        Thank you for completing the quiz! <br /> Here are your results:
+      </h1>
+      <div className={styles.container}>
+        <div className={styles.info}>
+          <h4>Overall:</h4>
+          <p>
+            You answered <span className={styles.focus}>5 out of 10</span> questions correctly
+          </p>
+          <p>
+            You've spend <span className={styles.focus}>2 min</span> to complete the quiz
+          </p>
+        </div>
+        <QuizResultsTable />
+      </div>
+      <div className={styles.buttons}>
+        <Link to="/game" className={styles.buttons__item}>
+          Restart
+        </Link>
+        <Link to="/" className={styles.buttons__item}>
+          Choose another quiz
+        </Link>
+      </div>
+    </div>
+  )
+}
+
+export default Results

--- a/src/styles/colors.scss
+++ b/src/styles/colors.scss
@@ -1,4 +1,6 @@
 $blue: #007bff;
 $blue-hover: #278efd;
-$white: white;
+$white: #ffffff;
 $white-low-accent: rgba(255, 255, 255, 0.6);
+$correct: #4be300;
+$incorrect: red;

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -3,6 +3,7 @@ export interface GameData {
   questionsAmount: number
   difficulty: 'Easy' | 'Medium' | 'Hard'
   type: 'Any type' | 'Multiple choice' | 'True/False'
+  time: number
 }
 
 export interface CurrentGameData {}


### PR DESCRIPTION
1. Add Results page UI without logic
- Add general result text
- Add result in numbers of correct answers
- Add Quiz configuration info
- Add text indicating how much time user took to answer all the questions
- Add “Restart” and “Choose another quiz” buttons
